### PR TITLE
升級的Apache Commons Collections中到V4.1

### DIFF
--- a/config-toolkit-parent/pom.xml
+++ b/config-toolkit-parent/pom.xml
@@ -23,7 +23,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.io.platform.version>1.1.2.RELEASE</spring.io.platform.version>
-		<apache.commons-collections.version>4.0</apache.commons-collections.version>
+		<apache.commons-collections.version>4.1</apache.commons-collections.version>
 		<druid.version>1.0.7</druid.version>
 		<curator.version>2.6.0</curator.version>
 		<cglib.version>2.2.2</cglib.version>


### PR DESCRIPTION
借助最崇高的敬意我要通知你，巨大的不幸降臨你的項目。Apache Commons Collections的4.0版具有CVSS漏洞的10.0。這是最壞的一種存在漏洞。僅僅通過對現有的類路徑，該庫將導致Java序列分析器整個JVM進程從一個狀態機圖靈機去。圖靈機與代碼執行的功能！

- https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
- https://commons.apache.org/proper/commons-collections/security-reports.html
- http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/

修復這個問題是非常重要的。如果與安全漏洞版本的Apache Commons Collections中是由任何傳遞依賴添加到Java類路徑，Java的反序列化對於整個JVM變得容易受到攻擊。該病毒是機載。這引起了可怕的痛苦為眾多開發者。所以這種變化並不僅僅保持這個項目的安全。這種變化也保證了ES用戶不會被攻擊。