### PR TITLE
修正ValueComplexResolvePostPrecessor中提前创建ValueAnnotationBeanPostProcessor导致部分配置无法注入到Bean中的问题

### DIFF
--- a/config-toolkit-demo/src/main/resources/config-toolkit-simplehotupdate-support.xml
+++ b/config-toolkit-demo/src/main/resources/config-toolkit-simplehotupdate-support.xml
@@ -26,7 +26,7 @@
 	</config:placeholder>
 
     <!-- hot update -->
-	<bean id="valueComplexResolvePostPrecessor" class="com.dangdang.config.service.support.spring.ValueComplexResolvePostPrecessor" init-method="init" destroy-method="shutdown">
+	<bean id="valueComplexResolvePostPrecessor" class="com.dangdang.config.service.support.spring.ValueComplexResolvePostPrecessor">
 		<property name="generalConfigGroups">
 			<set>
 				<ref bean="propertyGroup1" />

--- a/config-toolkit/src/main/java/com/dangdang/config/service/support/spring/InjectionDataHandler.java
+++ b/config-toolkit/src/main/java/com/dangdang/config/service/support/spring/InjectionDataHandler.java
@@ -35,7 +35,7 @@ import java.util.concurrent.Executors;
  */
 public class InjectionDataHandler implements ApplicationContextAware {
     protected final static Logger logger = LoggerFactory.getLogger(InjectionDataHandler.class);
-    private static Method NON_METHOD = ReflectionUtils.findMethod(InjectionDataHandler.class, "init");;
+    private static Method NON_METHOD = ReflectionUtils.findMethod(InjectionDataHandler.class, "init");
 
     private int threadSize = Runtime.getRuntime().availableProcessors() + 1;
     private ConcurrentHashMap<String, List<BeanInjectionMetaData>> injectionMetaDataCache = new ConcurrentHashMap<>();


### PR DESCRIPTION
修正ValueComplexResolvePostPrecessor中提前创建ValueAnnotationBeanPostProcessor导致部分配置无法注入到Bean中的问题